### PR TITLE
Fix script on Ubuntu systems

### DIFF
--- a/update
+++ b/update
@@ -20,7 +20,7 @@ if [ ! -f ${CONFIG} ]; then
   exit 1
 fi
 
-source ${CONFIG}
+. $(realpath ${CONFIG})
 
 FILE=${1:-$(ls -1 ivlist_* | tail -n1)}
 


### PR DESCRIPTION
Ubuntu uses dash as surrogate for /bin/sh instead of bash like
most other Linux distributions. Dash doesn't support the `source`
command, but only `.`.